### PR TITLE
Adding Missing Env Variables to Sidekiq service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - DISCOURSE_POSTGRESQL_NAME=bitnami_application
       - DISCOURSE_POSTGRESQL_USERNAME=bn_discourse
       - DISCOURSE_POSTGRESQL_PASSWORD=bitnami1
+      - DISCOURSE_HOST=discourse
+      - DISCOURSE_PORT=3000
 volumes:
   postgresql_data:
     driver: local


### PR DESCRIPTION
Sidekiq Nami Logic needs some Environment Variables which are not present on the `docker-compose.yml` file available at the root of the repo. Those changes were already applied on `docker-compose.yml` file under latest folder. See commit: `c605b0f0dbabb1a40f4fca2bc4256035d7b9740d`