### PR TITLE
Add Issues/PRs autoclose

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,7 +16,7 @@ staleLabel: stale
 issues:
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
-    This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contributions.
+    This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.
 
   # Comment to post when closing a stale Issue or Pull Request.
   closeComment: >
@@ -25,7 +25,7 @@ issues:
 pulls:
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
-    This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contributions.
+    This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.
 
   # Comment to post when closing a stale Issue or Pull Request.
   closeComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,35 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 15
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+daysUntilClose: 5
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - on-hold
+
+# Label to use when marking as stale
+staleLabel: stale
+
+issues:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contributions.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.
+
+pulls:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contributions.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30


### PR DESCRIPTION
**Description of the change**

Add auto-close to Issues and PRs in this repository. 

**Benefits**

After some days without activity, Issues and PRs will be closed automatically, in this case:
 - 15 days without activity: Send a message and add "stale" label.
 - 5 days without activity since the previous step: Close the Issue/PRs with a new message.
 - If we want to prevent this process from being applied to a specific issue/PR, for example, because it is blocked on our side, we should add the `on-hold` label to the issue/PR.