### PR TITLE
Add note on GMail smtp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,8 @@ This would be an example of SMTP configuration using a GMail account:
       - SMTP_PASSWORD=your_password
 
 ```
-You may need to turn on `Less secure app access` in your Google account security settings.
-Note that Google does not officially allow using GMail as an SMTP server so this should not be used in production.
-
-
+See the [documentation on troubleshooting SMTP issues](https://docs.bitnami.com/general/how-to/troubleshoot-smtp-issues/) if there are problems.
+In particular you will need to [make changes to your Google account settings](https://docs.bitnami.com/general/faq/troubleshooting/troubleshoot-smtp-gmail/) when using GMail.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ This would be an example of SMTP configuration using a GMail account:
 ```
 See the [documentation on troubleshooting SMTP issues](https://docs.bitnami.com/general/how-to/troubleshoot-smtp-issues/) if there are problems.
 In particular you will need to [make changes to your Google account settings](https://docs.bitnami.com/general/faq/troubleshooting/troubleshoot-smtp-gmail/) when using GMail.
+GMail also has [limits on the number of messages](https://support.google.com/a/answer/176600) that can be sent.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -376,8 +376,6 @@ This would be an example of SMTP configuration using a GMail account:
 
 ```
 See the [documentation on troubleshooting SMTP issues](https://docs.bitnami.com/general/how-to/troubleshoot-smtp-issues/) if there are problems.
-In particular you will need to [make changes to your Google account settings](https://docs.bitnami.com/general/faq/troubleshooting/troubleshoot-smtp-gmail/) when using GMail.
-GMail also has [limits on the number of messages](https://support.google.com/a/answer/176600) that can be sent.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,10 @@ This would be an example of SMTP configuration using a GMail account:
       - SMTP_PASSWORD=your_password
 
 ```
+You may need to turn on `Less secure app access` in your Google account security settings.
+Note that Google does not officially allow using GMail as an SMTP server so this should not be used in production.
+
+
 
 # Contributing
 


### PR DESCRIPTION
**Description of the change**

I followed the README instructions for setting up SMTP with GMail, but sending emails failed. After some investigation I discovered I needed to allow `Less secure app access` in the Google account security settings.

This also adds a note that GMail SMTP is not officially supported: https://github.com/discourse/discourse/blob/v2.3.0.beta9/lib/tasks/emails.rake#L65-L77

**Benefits**

README SMTP Gmail instructions are more likely to work for users

**Possible drawbacks**

**Applicable issues**

**Additional information**