### PR TITLE
Version changed and cant be downloaded

### DIFF
--- a/2/debian-10/Dockerfile
+++ b/2/debian-10/Dockerfile
@@ -12,7 +12,7 @@ RUN install_packages acl advancecomp ca-certificates curl file gifsicle gzip hos
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "python" "3.8.12-37" --checksum 3272da2099afdae735a7d3fb199e83f3bd74b44ebf6953e2f9a3dd0ad45091d1
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "wait-for-port" "1.0.1-10" --checksum 35c818ba3f4b5aae905959bc7d3a5e81fc63786e3c662b604612c0aa7fcda8fd
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "uglify-js" "3.15.2-1" --checksum 63173af1fbe2e7dabca039909facf71200aa74ea9f464fabc7a1114fe96248de
-RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ruby" "2.7.5-35" --checksum 98d92c65fc296f915a23ee5893fab07177f02274ec33887fb2e080c02e401dd4
+RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ruby" "2.7.4-35" --checksum 98d92c65fc296f915a23ee5893fab07177f02274ec33887fb2e080c02e401dd4
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "postgresql-client" "13.6.0-4" --checksum 10c4c8870775aa837cc37c243b20cde2efd166482aab0df90974c105884ea210
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "node" "14.19.0-4" --checksum 0649af9ad2856d01d574146b62c840d3a330f2e85227a2ae73ec6500737ccccc
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "git" "2.35.1-5" --checksum da12ba7cebb03c4eb983ba2248daf0ed5399be1bd8fa9d2d3931614ce6079ff6


### PR DESCRIPTION
Hi, edit pls the version of ruby.. the version 2.7.5 is not available for download

old: https://oss-binaries.phusionpassenger.com/binaries/passenger/by_release/6.0.12/rubyext-ruby-2.7.5-x86_64-linux.tar.gz

new: https://oss-binaries.phusionpassenger.com/binaries/passenger/by_release/6.0.12/rubyext-ruby-2.7.4-x86_64-linux.tar.gz

